### PR TITLE
feat: API-First Development with OpenAPI Specification

### DIFF
--- a/api/WORKFLOW.md
+++ b/api/WORKFLOW.md
@@ -142,7 +142,7 @@ FE and BE meet to:
 ### Spec Design
 - Use `$ref` for reusable schemas
 - Include examples in schemas
-- Use consistent naming (camelCase for JSON, snake_case for query params)
+- Use consistent naming (snake_case for JSON and query params)
 - Document all error responses
 
 ### Versioning

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -13,7 +13,7 @@ info:
 
     ### For Frontend
     - Generate TypeScript client: `npx openapi-typescript api/openapi.yaml -o types/api.ts`
-    - Run mock server: `npx prism mock api/openapi.yaml`
+    - Run mock server: `./api/scripts/generate-client.sh --mock`
   version: 1.0.0
   contact:
     name: Thiam Team

--- a/api/scripts/generate-client.sh
+++ b/api/scripts/generate-client.sh
@@ -89,10 +89,17 @@ else
             echo "Generated: $OUTPUT_DIR/api.ts"
             ;;
         fetch)
-            echo "Generating fetch client..."
+            echo "Generating TypeScript types for use with openapi-fetch..."
             npx openapi-typescript "$SPEC_FILE" -o "$OUTPUT_DIR/api.ts"
-            npx openapi-fetch "$SPEC_FILE" -o "$OUTPUT_DIR/client.ts"
-            echo "Generated: $OUTPUT_DIR/api.ts, $OUTPUT_DIR/client.ts"
+            echo "Generated: $OUTPUT_DIR/api.ts"
+            echo ""
+            echo "To use with openapi-fetch, install it in your project:"
+            echo "  npm install openapi-fetch"
+            echo ""
+            echo "Then use in your code:"
+            echo "  import createClient from 'openapi-fetch'"
+            echo "  import type { paths } from '$OUTPUT_DIR/api'"
+            echo "  const client = createClient<paths>({ baseUrl: 'http://localhost:8080' })"
             ;;
         axios)
             echo "Generating axios client..."
@@ -109,7 +116,9 @@ else
             ;;
     esac
 
-    echo ""
-    echo "Done! Import in your code:"
-    echo "  import type { paths, components } from '$OUTPUT_DIR/api'"
+    if [ "$OUTPUT_TYPE" = "typescript" ]; then
+        echo ""
+        echo "Done! Import in your code:"
+        echo "  import type { paths, components } from '$OUTPUT_DIR/api.ts'"
+    fi
 fi


### PR DESCRIPTION
## Summary
Set up OpenAPI specification structure to enable parallel frontend/backend development through contract-first design.

## Changes

### New Files
- `api/openapi.yaml` - OpenAPI 3.1 specification (source of truth for API contracts)
- `api/scripts/generate-client.sh` - Script for FE to generate TypeScript client
- `api/WORKFLOW.md` - Documentation for the API-first workflow

### What's Included in the Spec
- **Common Schemas**: Error, HealthStatus, Pagination
- **Reusable Parameters**: page, limit, id
- **Standard Responses**: 400, 401, 403, 404, 409, 500
- **Security Scheme**: Bearer JWT (ready for auth)
- **Health Endpoints**: /healthz, /readyz

## How It Works

```
1. DESIGN              2. PARALLEL DEV           3. INTEGRATE
   ──────────             ────────────              ─────────

   OpenAPI Spec    ──►    BE: Implement      ──►   FE connects
   (agreed)               handlers                 to real API
                   
                   ──►    FE: Build UI
                          with mock server
```

## Frontend Usage

```bash
# Generate TypeScript types
./api/scripts/generate-client.sh -o ./src/types

# Run mock server for development
./api/scripts/generate-client.sh --mock
```

## Test Plan
- [x] OpenAPI spec validates (YAML syntax)
- [x] Script is executable
- [x] Documentation covers workflow

## Next Steps
When starting a new feature/domain:
1. Design endpoints in `api/openapi.yaml`
2. FE generates client + runs mock server
3. Both teams implement in parallel
4. Integrate when ready

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)